### PR TITLE
feat: use-reducer as function using middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "use-typed-reducer",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "use-reducer React hook alternative",
     "author": "g4rcez",
     "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,33 +12,13 @@ export type Dispatch<ST, Fns extends Actions<Fns, ST>> = {
     [R in keyof Fns]: (...args: any[]) => Promise<(state: ST) => ST> | ((state: ST) => ST);
 };
 
-type ActionPropState<S, P> = (...args: any) => Promise<(state: S, props: P) => S> | ((state: S, props: P) => S);
-
-type ActionPropsState<A, S, P> = { [K in keyof A]: ActionPropState<S, P> };
-
-type DispatchProps<ST extends {}, P, Reducers extends ActionPropsState<Reducers, ST, P>> = {
-    [K in keyof Reducers]: (...args: any[]) => Promise<(state: ST, props: P) => ST> | ((state: ST, props: P) => ST);
-};
-
-type DefaultReducer<S extends {}> = (state: S) => S;
-
-type WithProps<S extends {}, P> = (state: S, props: P) => S;
-
-export type Reducer<S extends {}, A extends (...args: any) => DefaultReducer<S>> = (
-    ...params: Parameters<A>
-) => DefaultReducer<S>;
-
-export type ReducerWithProps<S extends {}, P extends {}, A extends (...args: any) => WithProps<S, P>> = (
-    ...params: Parameters<A>
-) => WithProps<S, P>;
-
 type MapArray<T, F> = { [K in keyof T]: [K, F] };
-
-const entries = <T extends {}, F>(t: T): MapArray<T[], F> => Object.entries(t) as any;
 
 type RemoveReduceReturns<State extends {}, Reducers extends Dispatch<State, Reducers>> = {
     [R in keyof Reducers]: VoidableFn<Reducers[R]>;
 };
+
+const entries = <T extends {}, F>(t: T): MapArray<T[], F> => Object.entries(t) as any;
 
 export const useTypedReducer = <State extends {}, Reducers extends Dispatch<State, Reducers>>(
     initialState: State,
@@ -62,49 +42,17 @@ export const useTypedReducer = <State extends {}, Reducers extends Dispatch<Stat
     return [state, dispatches];
 };
 
-export const useReducerWithProps = <
-    State extends {},
-    Props extends {},
-    Reducers extends DispatchProps<State, Props, Reducers>
->(
-    initialState: State,
-    props: Props,
-    reducers: Reducers
-): [state: State, dispatch: Reducers] => {
-    const [state, setState] = useState(initialState);
-    const refProps = useRef<Props>(props);
-
-    useEffect(() => {
-        refProps.current = props;
-    }, [props]);
-
-    const dispatches = useMemo(() => {
-        return entries<Reducers, ActionPropState<State, Props>>(reducers).reduce(
-            (acc, [name, dispatch]) => ({
-                ...acc,
-                [name]: async (...params: unknown[]) => {
-                    const dispatcher = await dispatch(...params);
-                    setState((previousState: State) => dispatcher(previousState, refProps.current));
-                }
-            }),
-            reducers
-        );
-    }, [reducers]);
-
-    return [state, dispatches];
-};
-
 type FnMap<State> = { [k: string]: (...args: any[]) => Partial<State> | Promise<Partial<State>> };
 
 type MappedReducers<State extends {}, Fns extends FnMap<State>> = {
-    [F in keyof Fns]: (...args: Parameters<Fns[F]>) => State | Promise<State>;
+    [F in keyof Fns]: (
+        ...args: Parameters<Fns[F]>
+    ) => State | Promise<State> | Partial<State> | Promise<Partial<State>>;
 };
 
-type MapReducerReturn<State extends {}, Fns extends FnMap<State>> = {
-    [F in keyof Fns]: VoidableFn<Fns[F]>;
-};
+type MapReducerReturn<State extends {}, Fns extends FnMap<State>> = { [F in keyof Fns]: VoidableFn<Fns[F]> };
 
-const useMutable = <T extends {}>(state: T) => {
+export const useMutable = <T extends {}>(state: T) => {
     const mutable = useRef(state ?? {});
     useEffect(() => void (mutable.current = state), [state]);
     return mutable;
@@ -122,9 +70,10 @@ export const useReducer = <
     const [state, setState] = useState<State>(() => initialState);
     const mutableState = useMutable(state);
     const mutableProps = useMutable(props ?? {});
+    const mutableReducer = useMutable(reducer);
 
     const dispatchers = useMemo(() => {
-        const reducers = reducer(
+        const reducers = mutableReducer.current(
             () => mutableState.current,
             () => (mutableProps.current as Props) ?? ({} as Props)
         );
@@ -134,13 +83,14 @@ export const useReducer = <
                 [name]: (...params: unknown[]) => {
                     const newState = dispatch(...params);
                     return newState instanceof Promise
-                        ? newState.then((state) => void setState((prev) => ({ ...prev, ...state })))
-                        : setState((previousState: State) => ({ ...previousState, ...newState }));
+                        ? void newState.then((state) => void setState((prev) => ({ ...prev, ...state })))
+                        : setState((prev) => ({ ...prev, ...newState }));
                 }
             }),
             reducers
         );
     }, []);
+
     return [state, dispatchers as any];
 };
 


### PR DESCRIPTION
# Context

Some features at this new version

## Middlewares

Using middlewares you can intercept all state mutation without an `useEffect`, before the React updates. This is useful when you need to store your state in LocalStorage/SessionStorage