### PR TITLE
feat: createGlobalReducer improvements + add props to useTypedReducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "use-typed-reducer",
     "type": "module",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "description": "use-reducer React hook alternative",
     "author": "g4rcez",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "use-typed-reducer",
     "type": "module",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "description": "use-reducer React hook alternative",
     "author": "g4rcez",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "use-typed-reducer",
     "type": "module",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "use-reducer React hook alternative",
     "author": "g4rcez",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "use-typed-reducer",
     "type": "module",
-    "version": "3.3.0-2",
+    "version": "3.3.0",
     "description": "use-reducer React hook alternative",
     "author": "g4rcez",
     "license": "MIT",

--- a/src/shallow-compare.ts
+++ b/src/shallow-compare.ts
@@ -1,29 +1,40 @@
 const isPrimitive = (a: any): a is string | number | boolean => {
     const type = typeof a;
-    return type === "string" || type === "number" || type === "bigint" || type === "boolean" || type === "undefined" || type === null
-}
+    return (
+        type === "string" ||
+        type === "number" ||
+        type === "bigint" ||
+        type === "boolean" ||
+        type === "undefined" ||
+        type === null
+    );
+};
 
 export const shallowCompare = (left: any, right: any): boolean => {
     if (left === right || Object.is(left, right)) return true;
     if (Array.isArray(left) && Array.isArray(right)) {
-        if (left.length !== right.length) return false
+        if (left.length !== right.length) return false;
     }
-    if (left && right && typeof left === 'object' && typeof right === 'object') {
+    if (left && right && typeof left === "object" && typeof right === "object") {
         if (left.constructor !== right.constructor) return false;
         if (left.valueOf !== Object.prototype.valueOf) return left.valueOf() === right.valueOf();
         const keys = Object.keys(left);
         length = keys.length;
-        if (length !== Object.keys(right).length) return false;
-        let i = length
-        for (; i-- !== 0;) {
-            if (!Object.prototype.hasOwnProperty.call(right, keys[i])) return false;
+        if (length !== Object.keys(right).length) {
+            return false;
         }
-        i = length
-        for (let i = length; i-- !== 0;) {
+        let i = length;
+        for (; i-- !== 0; ) {
+            if (!Object.prototype.hasOwnProperty.call(right, keys[i])) {
+                return false;
+            }
+        }
+        i = length;
+        for (let i = length; i-- !== 0; ) {
             const key = keys[i];
-            if (!(isPrimitive(left[key]) && isPrimitive(right[key]) && (right[key] === left[key]))) return false;
+            if (!(isPrimitive(left[key]) && isPrimitive(right[key]) && right[key] === left[key])) return false;
         }
         return true;
     }
     return left !== left && right !== right;
-}
+};

--- a/tests/shallow-compare.test.ts
+++ b/tests/shallow-compare.test.ts
@@ -18,12 +18,11 @@ describe("Should test shallow compare", () => {
 
     test("✅empty array equals", () => expect(shallowCompare([], [])).toBe(true));
 
-    test("✅ diff instances empty", () => {
+    test("✅diff instances empty", () => {
         class Test {
             public constructor(public value: string) {}
         }
-
-        expect(shallowCompare(new Test(""), new Test(""))).toBe(false);
+        expect(shallowCompare(new Test(""), new Test(""))).toBe(true);
     });
 
     test("🚨diff object", () => expect(shallowCompare({ a: 2 }, { a: 1 })).toBe(false));

--- a/tests/use-global-reducer.test.ts
+++ b/tests/use-global-reducer.test.ts
@@ -15,4 +15,14 @@ describe("Should test createGlobalReducer", () => {
         });
         expect(result.current[0].name).toBe("hello: Bar Foo");
     });
+
+    test("Should compare the useStore.dispatchers and useStore()[1]", () => {
+        const useStore = createGlobalReducer({ n: 0 }, (args) => ({
+            inc: () => ({ n: args.state().n + 1 })
+        }));
+        const { result } = renderHook(() => useStore());
+        const [state, dispatch] = result.current;
+        expect(state.n).toBe(0);
+        expect(dispatch).toStrictEqual(useStore.dispatchers);
+    });
 });

--- a/tests/use-typed-reducer.test.ts
+++ b/tests/use-typed-reducer.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import useReducer from "../src";
+
+type State = { name: string };
+
+type Props = { firstName: string };
+
+describe("Should test useReducer", () => {
+    test("Should create hook", async () => {
+        const { result } = renderHook(() =>
+            useReducer(
+                { name: "Foo" },
+                {
+                    greeting:
+                        (name?: string) =>
+                        (state: State, props: Props): State => ({ ...state, name: name ?? props.firstName })
+                },
+                { firstName: "Joe" }
+            )
+        );
+        const [state, dispatch] = result.current;
+        expect(state.name).toBe("Foo");
+        act(async () => {
+            dispatch.greeting();
+        }).then(() => {
+            expect(result.current[0].name).toBe("Joe");
+        });
+        act(() => {
+            dispatch.greeting("Foo");
+            expect(result.current[0].name).toBe("Foo");
+        });
+    });
+});


### PR DESCRIPTION
# Context

## Add `dispatchers` to return of `createGlobalReducer`.

Now you can modify your state outside of react components. E.g:

```typescript jsx
import { createGlobalReducer } from "use-typed-reducer";

const useStore = createGlobalReducer({ name: "Foo" }, (args) => ({
    greeting: (hello: string) => ({ name: `hello: ${hello} ${args.state().name}` })
}));

const dispatchers = useStore.dispatchers;
```

With `dispatchers` you can set a state update outside of component. This is very useful if you create functions outside your component but need to access the state

## Props in useTypedReducer

To grant the same API to all useTypedReducer hooks, now you can use props from outside of `useTypedReducer` hook as `useReducer` and `createGlobalReducer`.
